### PR TITLE
Update auth middleware to parse Bearer token

### DIFF
--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"os"
+	"strings"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/golang-jwt/jwt/v5"
@@ -14,7 +15,12 @@ func Protected() fiber.Handler {
 		if auth == "" {
 			return c.SendStatus(fiber.StatusUnauthorized)
 		}
-		token, err := jwt.Parse(auth, func(t *jwt.Token) (interface{}, error) {
+		parts := strings.SplitN(auth, " ", 2)
+		if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+			return c.SendStatus(fiber.StatusUnauthorized)
+		}
+		tokenStr := parts[1]
+		token, err := jwt.Parse(tokenStr, func(t *jwt.Token) (interface{}, error) {
 			return []byte(getSecret()), nil
 		})
 		if err != nil || !token.Valid {

--- a/postman/go-fiber-postgres.postman_collection.json
+++ b/postman/go-fiber-postgres.postman_collection.json
@@ -57,7 +57,7 @@
       "request": {
         "method": "GET",
         "header": [
-          {"key": "Authorization", "value": "<token>"}
+          {"key": "Authorization", "value": "Bearer {{token}}"}
         ],
         "url": {
           "raw": "{{baseUrl}}/api/me",


### PR DESCRIPTION
## Summary
- update JWT middleware to expect `Authorization: Bearer <token>` header
- update Postman collection accordingly

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68679d61231c8331b2947a908d9b2d98